### PR TITLE
Use T&L's Accounts API token rather than Finance's

### DIFF
--- a/PersonListener/serverless.yml
+++ b/PersonListener/serverless.yml
@@ -25,7 +25,7 @@ functions:
       TenureApiUrl: ${ssm:/housing-tl/${self:provider.stage}/tenure-api-url}
       TenureApiToken: ${ssm:/housing-tl/${self:provider.stage}/tenure-api-token}
       AccountApiUrl: ${ssm:/housing-finance/${self:provider.stage}/account-api-url}
-      AccountApiToken: ${ssm:/housing-finance/${self:provider.stage}/account-api-token}
+      AccountApiToken: ${ssm:/housing-tl/${self:provider.stage}/account-api-token}
     events:
       # Specify the parameter containing the queue arn used to trigget the lambda function here
       # This will have been defined in the terraform configuration


### PR DESCRIPTION
Update the Accounts API token to use a specific MTFH: T&L token to avoid conflicts with MTFH: Finance.