### PR TITLE
Fix framework specification in build script

### DIFF
--- a/PersonListener/build.sh
+++ b/PersonListener/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework 8.0 --output-package ./bin/release/net8.0/person-listener.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/person-listener.zip


### PR DESCRIPTION
Correct the framework version specification for the `dotnet lambda package` command.
