### PR TITLE
Fix `development` environment Terraform deployment not applying the infrastructure changes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
   terraform-apply-development:
     executor: docker-terraform
     steps:
-      - terraform-init-then-plan:
+      - terraform-apply:
           environment: "development"
   terraform-init-and-plan-staging:
     executor: docker-terraform


### PR DESCRIPTION
# What:
 - Fix `housing-development` Terraform infrastructure deployment job failing to deploy infrastructure.

# Why:
 - Needed to deploy the security group from this PR #57 .

# Notes:
 - The development terraform deployment for some reason was referencing the plan job rather than apply.