### PR TITLE
Add missing security group ids and replace non-existing subnet ids `[Pt2]`.

### DIFF
--- a/PersonListener/serverless.yml
+++ b/PersonListener/serverless.yml
@@ -140,6 +140,8 @@ custom:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656
     production:
+      securityGroupIds:
+        - sg-0d35b31c1d389a4db
       subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34

--- a/PersonListener/serverless.yml
+++ b/PersonListener/serverless.yml
@@ -130,6 +130,8 @@ resources:
 custom:
   vpc:
     development:
+      securityGroupIds:
+        - sg-096cc425cd4b8803a
       subnetIds:
         - subnet-0140d06fb84fdb547
         - subnet-05ce390ba88c42bfd

--- a/PersonListener/serverless.yml
+++ b/PersonListener/serverless.yml
@@ -131,8 +131,8 @@ custom:
   vpc:
     development:
       subnetIds:
-        - subnet-0deabb5d8fb9c3446
-        - subnet-000b89c249f12a8ad
+        - subnet-0140d06fb84fdb547
+        - subnet-05ce390ba88c42bfd
     staging:
       securityGroupIds:
         - sg-087896a42ab45a21f

--- a/PersonListener/serverless.yml
+++ b/PersonListener/serverless.yml
@@ -134,6 +134,8 @@ custom:
         - subnet-0deabb5d8fb9c3446
         - subnet-000b89c249f12a8ad
     staging:
+      securityGroupIds:
+        - sg-087896a42ab45a21f
       subnetIds:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656

--- a/PersonListener/serverless.yml
+++ b/PersonListener/serverless.yml
@@ -137,8 +137,8 @@ custom:
       securityGroupIds:
         - sg-087896a42ab45a21f
       subnetIds:
-        - subnet-06d3de1bd9181b0d7
-        - subnet-0ed7d7713d1127656
+        - subnet-0ea0020a44b98a2ca
+        - subnet-0743d86e9b362fa38
     production:
       securityGroupIds:
         - sg-0d35b31c1d389a4db

--- a/PersonListener/serverless.yml
+++ b/PersonListener/serverless.yml
@@ -143,5 +143,5 @@ custom:
       securityGroupIds:
         - sg-0d35b31c1d389a4db
       subnetIds:
-        - subnet-01d3657f97a243261
-        - subnet-0b7b8fea07efabf34
+        - subnet-0beb266003a56ca82
+        - subnet-06a697d86a9b6ed01


### PR DESCRIPTION
# What:
 - Correct the VPC subnet ids for all environments.
 - Add missing security group ids for all environments.

# Why:
 - To fix the AWS lambda attachment to VPC configuration.

# Notes:
 - The VPC ids weren't discovered to be wrong because the pipeline never got to the point of actually attempting to use them due to pipeline error.