### PR TITLE
Resolve Dockerfile SonarCloud warnings & improve readme.

### DIFF
--- a/PersonListener.Tests/Dockerfile
+++ b/PersonListener.Tests/Dockerfile
@@ -10,8 +10,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN dotnet restore ./PersonListener/PersonListener.csproj
-RUN dotnet restore ./PersonListener.Tests/PersonListener.Tests.csproj
+RUN dotnet restore
 
 RUN dotnet build -c Release -o out PersonListener/PersonListener.csproj
 RUN dotnet build -c debug -o out PersonListener.Tests/PersonListener.Tests.csproj

--- a/PersonListener.Tests/Dockerfile
+++ b/PersonListener.Tests/Dockerfile
@@ -1,6 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0
 
-# disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
 ENV DynamoDb_LocalMode='true'
@@ -9,7 +8,6 @@ ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 
 WORKDIR /app
 
-# Copy csproj and restore as distinct layers
 COPY ./PersonListener.sln ./
 COPY ./PersonListener/PersonListener.csproj ./PersonListener/
 COPY ./PersonListener.Tests/PersonListener.Tests.csproj ./PersonListener.Tests/
@@ -18,7 +16,6 @@ COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
 RUN dotnet restore ./PersonListener/PersonListener.csproj
 RUN dotnet restore ./PersonListener.Tests/PersonListener.Tests.csproj
 
-# Copy everything else and build
 COPY . .
 
 RUN dotnet build -c Release -o out PersonListener/PersonListener.csproj

--- a/PersonListener.Tests/Dockerfile
+++ b/PersonListener.Tests/Dockerfile
@@ -8,15 +8,11 @@ ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 
 WORKDIR /app
 
-COPY ./PersonListener.sln ./
-COPY ./PersonListener/PersonListener.csproj ./PersonListener/
-COPY ./PersonListener.Tests/PersonListener.Tests.csproj ./PersonListener.Tests/
 COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
+COPY . .
 
 RUN dotnet restore ./PersonListener/PersonListener.csproj
 RUN dotnet restore ./PersonListener.Tests/PersonListener.Tests.csproj
-
-COPY . .
 
 RUN dotnet build -c Release -o out PersonListener/PersonListener.csproj
 RUN dotnet build -c debug -o out PersonListener.Tests/PersonListener.Tests.csproj

--- a/PersonListener.Tests/Dockerfile
+++ b/PersonListener.Tests/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /app
 
 COPY . .
 
-RUN dotnet restore
-
 RUN dotnet build
+
 ENTRYPOINT ["dotnet", "test", "--collect", "XPlat Code Coverage;Format=opencover", "--results-directory", "./coverage"]

--- a/PersonListener.Tests/Dockerfile
+++ b/PersonListener.Tests/Dockerfile
@@ -12,7 +12,5 @@ COPY . .
 
 RUN dotnet restore
 
-RUN dotnet build -c Release -o out PersonListener/PersonListener.csproj
-RUN dotnet build -c debug -o out PersonListener.Tests/PersonListener.Tests.csproj
-
+RUN dotnet build
 ENTRYPOINT ["dotnet", "test", "--collect", "XPlat Code Coverage;Format=opencover", "--results-directory", "./coverage"]

--- a/PersonListener.Tests/Dockerfile
+++ b/PersonListener.Tests/Dockerfile
@@ -8,7 +8,6 @@ ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 
 WORKDIR /app
 
-COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
 COPY . .
 
 RUN dotnet restore ./PersonListener/PersonListener.csproj

--- a/README.md
+++ b/README.md
@@ -28,45 +28,6 @@ Person listener does the above-described table data copying plumbing behind the 
 4. Rename the initial template.
 5. Open it in your IDE.
 
-### Renaming
-
-The renaming of `PersonListener` into `SomethingElseListener` can be done by running a Renamer powershell script. To do so:
-1. Open the powershell and navigate to this directory's root.
-2. Run the script using the following command:
-```
-.\Renamer.ps1 -name SomethingElseListener -alternateName something-else-listener
-```
-
-The `name` value is the name of the Listener and will be used is the Project names.
-The `alternateName` value is the lower case name used in docker compose and for various behind-the-scenes file names.
-
-If your ***script execution policy*** prevents you from running the script, you can temporarily ***bypass*** that with:
-```
-powershell -noprofile -ExecutionPolicy Bypass -file .\Renamer.ps1 -name SomethingElseListener -alternateName something-else-listener
-```
-
-Or you can change your execution policy, prior to running the script, permanently with _(this disables security so, be cautious)_:
-```
-Set-ExecutionPolicy Unrestricted
-```
-
-After the renaming is done, the ***script will ask you if you want to delete it as well***, as it's useless now - It's your choice.
-
-#### On OSX
-
-Use Docker to run this script on Macs:
-```
-docker run -it -v `pwd`:/app mcr.microsoft.com/powershell
-```
-
-#### On *nix
-
-Run the renamer.sh bash script from the project root:
-```
-./rename.sh MyApiName
-```
-Ideally you should provide a script argument in PascalCase as in the example. The script will rename all instances of base api without changing the original casing.
-
 ### Development
 
 To serve the application, run it using your IDE of choice, we use Visual Studio CE and JetBrains Rider on Mac.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
-# LBH Person Listener
+# Person Listener
 
-Listener application implementing an AWS function to receive messages that will result in additional processing within the person domain
+Listener application implementing an AWS function to receive messages that will result in additional processing within the person domain.
+
+Whenever a person record gets assigned / removed to any given tenancy agreement record, this ends up firing off an event of a
+corresponding type. This listener picks this event up, and links up the tenancy agreement record by attaching / removing it to/from
+the person record.
+
+Tenancy Agreement DynamoDB table document details are being duplicated within the Person DynamoDB document record. This creates a
+constraint where the Tenancy data needs to be synced between the two tables. This appears in the form of the above tenanancy
+agreement being attached / removed as partial copy of the full tenancy agreement table record. However, this also results in
+person DynamoDB record needing to be updated whenever there are any changes to the tenancy details, or payment reference number.
+
+Person listener does the above-described table data copying plumbing behind the scenes to ensure that these linked up tables are in sync.
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ person DynamoDB record needing to be updated whenever there are any changes to t
 Person listener does the above-described table data copying plumbing behind the scenes to ensure that these linked up tables are in sync.
 
 ## Stack
-
 - .NET Core as a web framework.
 - xUnit as a test framework.
 
@@ -36,6 +35,3 @@ See contributing instructions within the contribution readme: [link](https://git
 ### Other Contacts
 
 - **Rashmi Shetty**, Product Owner at London Borough of Hackney (rashmi.shetty@hackney.gov.uk)
-
-[docker-download]: https://www.docker.com/products/docker-desktop
-[AWS-CLI]: https://aws.amazon.com/cli/

--- a/README.md
+++ b/README.md
@@ -18,48 +18,11 @@ Person listener does the above-described table data copying plumbing behind the 
 - .NET Core as a web framework.
 - xUnit as a test framework.
 
-
 ## Setup
-
-1. Install [Docker][docker-download].
-2. Install [AWS CLI][AWS-CLI].
-3. Clone this repository.
-4. Rename the initial template.
-5. Open it in your IDE.
+See setup instructions within the setup readme: [link](https://github.com/LBHackney-IT/person-listener/blob/master/docs/Setup.md).
 
 ## Contributing
-See contributing instructions within the following readme: [link](https://github.com/LBHackney-IT/person-listener/blob/master/docs/Contributing.md).
-
-## Development
-
-To serve the application, run it using your IDE of choice, we use Visual Studio CE and JetBrains Rider on Mac.
-
-**Note**
-When running locally the appropriate database conneciton details are still needed.
-
-### DynamoDb
-To use a local instance of DynamoDb, this will need to be installed. This is most easily done using [Docker](https://www.docker.com/products/docker-desktop).
-Run the following command, specifying the local path where you want the container's shared volume to be stored.
-```
-docker run --name dynamodb-local -p 8000:8000 -v <PUT YOUR LOCAL PATH HERE>:/data/ amazon/dynamodb-local -jar DynamoDBLocal.jar -sharedDb -dbPath /data
-```
-
-If you would like to see what is in your local DynamoDb instance using a simple gui, then [this admin tool](https://github.com/aaronshaf/dynamodb-admin) can do that.
-
-The application can also be served locally using docker:
-1.  Add you security credentials to AWS CLI.
-```sh
-$ aws configure
-```
-2. Log into AWS ECR.
-```sh
-$ aws ecr get-login --no-include-email
-```
-3. Build and serve the application. It will be available in the port 3000.
-```sh
-$ make build && make serve
-```
-
+See contributing instructions within the contribution readme: [link](https://github.com/LBHackney-IT/person-listener/blob/master/docs/Contributing.md).
 
 
 ## Contacts

--- a/README.md
+++ b/README.md
@@ -24,14 +24,5 @@ See setup instructions within the setup readme: [link](https://github.com/LBHack
 See contributing instructions within the contribution readme: [link](https://github.com/LBHackney-IT/person-listener/blob/master/docs/Contributing.md).
 
 
-## Contacts
-
-### Active Maintainers
-
-- **Selwyn Preston**, Lead Developer at London Borough of Hackney (selwyn.preston@hackney.gov.uk)
-- **Mirela Georgieva**, Lead Developer at London Borough of Hackney (mirela.georgieva@hackney.gov.uk)
-- **Matt Keyworth**, Lead Developer at London Borough of Hackney (matthew.keyworth@hackney.gov.uk)
-
-### Other Contacts
-
-- **Rashmi Shetty**, Product Owner at London Borough of Hackney (rashmi.shetty@hackney.gov.uk)
+## Ownership
+**Housing Products Team**, [@LBHackney-IT/teams/housing-products](https://github.com/orgs/LBHackney-IT/teams/housing-products).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,5 @@ See setup instructions within the setup readme: [link](https://github.com/LBHack
 ## Contributing
 See contributing instructions within the contribution readme: [link](https://github.com/LBHackney-IT/person-listener/blob/master/docs/Contributing.md).
 
-
 ## Ownership
-**Housing Products Team**, [@LBHackney-IT/teams/housing-products](https://github.com/orgs/LBHackney-IT/teams/housing-products).
+**Housing Products Team**, [@LBHackney-IT/housing-products](https://github.com/orgs/LBHackney-IT/teams/housing-products).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Person Listener
-
-Listener application implementing an AWS function to receive messages that will result in additional processing within the person domain.
+Event-driven, AWS Lambda hosted application used to keep Person DynamoDB record details up-to-date.
 
 Whenever a person record gets assigned / removed to any given tenancy agreement record, this ends up firing off an event of a
 corresponding type. This listener picks this event up, and links up the tenancy agreement record by attaching / removing it to/from

--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Person listener does the above-described table data copying plumbing behind the 
 - .NET Core as a web framework.
 - xUnit as a test framework.
 
-## Contributing
 
-### Setup
+## Setup
 
 1. Install [Docker][docker-download].
 2. Install [AWS CLI][AWS-CLI].
@@ -28,14 +27,17 @@ Person listener does the above-described table data copying plumbing behind the 
 4. Rename the initial template.
 5. Open it in your IDE.
 
-### Development
+## Contributing
+See contributing instructions within the following readme: [link](https://github.com/LBHackney-IT/person-listener/blob/master/docs/Contributing.md).
+
+## Development
 
 To serve the application, run it using your IDE of choice, we use Visual Studio CE and JetBrains Rider on Mac.
 
 **Note**
 When running locally the appropriate database conneciton details are still needed.
 
-##### DynamoDb
+### DynamoDb
 To use a local instance of DynamoDb, this will need to be installed. This is most easily done using [Docker](https://www.docker.com/products/docker-desktop).
 Run the following command, specifying the local path where you want the container's shared volume to be stored.
 ```
@@ -58,68 +60,7 @@ $ aws ecr get-login --no-include-email
 $ make build && make serve
 ```
 
-### Release process
 
-We use a pull request workflow, where changes are made on a branch and approved by one or more other maintainers before the developer can merge into `master` branch.
-
-![Circle CI Workflow Example](docs/circle_ci_workflow.png)
-
-Then we have an automated six step deployment process, which runs in CircleCI.
-
-1. Automated tests (xUnit) are run to ensure the release is of good quality.
-2. The application is deployed to development automatically, where we check our latest changes work well.
-3. We manually confirm a staging deployment in the CircleCI workflow once we're happy with our changes in development.
-4. The application is deployed to staging.
-5. We manually confirm a production deployment in the CircleCI workflow once we're happy with our changes in staging.
-6. The application is deployed to production.
-
-Our staging and production environments are hosted by AWS. We would deploy to production per each feature/config merged into  `release`  branch.
-
-### Creating A PR
-
-To help with making changes to code easier to understand when being reviewed, we've added a PR template.
-When a new PR is created on a repo that uses this API template, the PR template will automatically fill in the `Open a pull request` description textbox.
-The PR author can edit and change the PR description using the template as a guide.
-
-## Static Code Analysis
-
-### Using [FxCop Analysers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers)
-
-FxCop runs code analysis when the Solution is built.
-
-Both the API and Test projects have been set up to **treat all warnings from the code analysis as errors** and therefore, fail the build.
-
-However, we can select which errors to suppress by setting the severity of the responsible rule to none, e.g `dotnet_analyzer_diagnostic.<Category-or-RuleId>.severity = none`, within the `.editorconfig` file.
-Documentation on how to do this can be found [here](https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019).
-
-## Testing
-
-### Run the tests
-
-```sh
-$ make test
-```
-
-### Agreed Testing Approach
-- Use xUnit, FluentAssertions and Moq
-- Always follow a TDD approach
-- Tests should be independent of each other
-- Gateway tests should interact with a real test instance of the database
-- Test coverage should never go down. (See the [test project readme](PersonListener.Tests/readme.md#Run-coverage) for how to run a coverage check.)
-- All use cases should be covered by E2E tests
-- Optimise when test run speed starts to hinder development
-- Unit tests and E2E tests should run in CI
-- Test database schemas should match up with production database schema
-- Have integration tests which test from the DynamoDb database to API Gateway
-
-## Data Migrations
-### A good data migration
-- Record failure logs
-- Automated
-- Reliable
-- As close to real time as possible
-- Observable monitoring in place
-- Should not affect any existing databases
 
 ## Contacts
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Person listener does the above-described table data copying plumbing behind the 
 ## Stack
 - .NET Core as a web framework.
 - xUnit as a test framework.
+- Docker for tests for ease of running them within pipeline.
+- Hosted as an AWS Serverless Lambda.
+- Deployed to AWS CloudFormation using Serverless Framework.
+- Remaining related infrastructure deployed using Terraform.
+- Code QA checks & deployment is done within CircleCI pipelines.
 
 ## Setup
 See setup instructions within the setup readme: [link](https://github.com/LBHackney-IT/person-listener/blob/master/docs/Setup.md).

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,0 +1,64 @@
+# Contributing
+
+## Release process
+
+We use a pull request workflow, where changes are made on a branch and approved by one or more other maintainers before the developer can merge into `master` branch.
+
+![Circle CI Workflow Example](docs/circle_ci_workflow.png)
+
+Then we have an automated six step deployment process, which runs in CircleCI.
+
+1. Automated tests (xUnit) are run to ensure the release is of good quality.
+2. The application is deployed to development automatically, where we check our latest changes work well.
+3. We manually confirm a staging deployment in the CircleCI workflow once we're happy with our changes in development.
+4. The application is deployed to staging.
+5. We manually confirm a production deployment in the CircleCI workflow once we're happy with our changes in staging.
+6. The application is deployed to production.
+
+Our staging and production environments are hosted by AWS. We would deploy to production per each feature/config merged into  `release`  branch.
+
+## Creating A PR
+
+To help with making changes to code easier to understand when being reviewed, we've added a PR template.
+When a new PR is created on a repo that uses this API template, the PR template will automatically fill in the `Open a pull request` description textbox.
+The PR author can edit and change the PR description using the template as a guide.
+
+# Static Code Analysis
+
+## Using [FxCop Analysers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers)
+
+FxCop runs code analysis when the Solution is built.
+
+Both the API and Test projects have been set up to **treat all warnings from the code analysis as errors** and therefore, fail the build.
+
+However, we can select which errors to suppress by setting the severity of the responsible rule to none, e.g `dotnet_analyzer_diagnostic.<Category-or-RuleId>.severity = none`, within the `.editorconfig` file.
+Documentation on how to do this can be found [here](https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019).
+
+## Testing
+
+### Run the tests
+
+```sh
+$ make test
+```
+
+### Agreed Testing Approach
+- Use xUnit, FluentAssertions and Moq
+- Always follow a TDD approach
+- Tests should be independent of each other
+- Gateway tests should interact with a real test instance of the database
+- Test coverage should never go down. (See the [test project readme](PersonListener.Tests/readme.md#Run-coverage) for how to run a coverage check.)
+- All use cases should be covered by E2E tests
+- Optimise when test run speed starts to hinder development
+- Unit tests and E2E tests should run in CI
+- Test database schemas should match up with production database schema
+- Have integration tests which test from the DynamoDb database to API Gateway
+
+## Data Migrations
+### A good data migration
+- Record failure logs
+- Automated
+- Reliable
+- As close to real time as possible
+- Observable monitoring in place
+- Should not affect any existing databases

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,0 +1,67 @@
+# Setup
+
+## Dependencies
+1. Install [Docker][docker-download].
+2. Install [AWS CLI][AWS-CLI].
+3. Install the dotnet SDK and dotnet Runtime version matching those specified in `.csproj` files.
+4. Install `git` versioning software. Intall it with `git bash` if you're on Windows.
+5. Configure your git credentials with personal access token (PAT) from Github. This token needs to be SSO authorized within Github settings.
+
+## Open the project
+1. Clone this repository using `git clone` command that Github provides.
+2. Open it in your IDE _(Integrated development environment)_.
+3. Configure any needed environment variables within an `.env` file or within your environment.
+
+## Integrated development environment
+There are many options available. What fits you best will depend on your Operating System, you preference on Open Source, and your preference convenience in terms of reducing configuration needed.
+
+Common options used in Hackney:
+1. Visual Studio Code _(great & common-choice IDE for both front-end and back-end, requires installing a few pluggins, and doing minor configuration)_
+2. Visual Studio _(only available on Mac and Windows, best on Windows. Nearly everything C# works w/o the need for extra configuration apart the setup wizard prompt it requires you to go through)_
+3. JetBrains Rider _(offers a bunch of convenience, available on all OS'es, however, requires paid subscription)_
+
+## Running project locally
+So long as you have the correct dotnet SDK and runtime installed, there shouldn't be any issue.
+If you don't have those installed, you can still use docker container to run the application.
+
+The launching of the application can be done in multiple ways, either through the IDE user interface buttons,
+or via dotnet command-line-interface by running `dotnet run`.
+
+**Note**
+When running locally the appropriate database connection details and other environment variables like Nuget token are still needed.
+
+## DynamoDb
+To use a local instance of DynamoDb, this will need to be installed. This is most easily done using [Docker](https://www.docker.com/products/docker-desktop).
+Run the following command, specifying the local path where you want the container's shared volume to be stored.
+```
+docker run --name dynamodb-local -p 8000:8000 -v <PUT YOUR LOCAL PATH HERE>:/data/ amazon/dynamodb-local -jar DynamoDBLocal.jar -sharedDb -dbPath /data
+```
+
+If you would like to see what is in your local DynamoDb instance using a simple gui, then [this admin tool](https://github.com/aaronshaf/dynamodb-admin) can do that.
+
+The application can also be served locally using docker:
+1.  Add you security credentials to AWS CLI.
+```sh
+$ aws configure
+```
+<!-- The log in to ECR makes no sense to me. If anyone's done this setup, please elaborate. -->
+2. Log into AWS ECR.
+```sh
+$ aws ecr get-login --no-include-email
+```
+3. Build and serve the application. It will be available in the port 3000.
+```sh
+$ make build && make serve
+```
+
+## Run the tests locally
+Run the tests within the Docker container:
+```sh
+$ make test
+```
+
+Alternatively, run the tests locally:
+```sh
+dotnet test
+```
+However, you may still need to launch the database container separately if it's used by the tests.


### PR DESCRIPTION
# What:
 - Resolve Dockerfile issues flagged by SonarCloud.
 - Declutter the project readme. 

# Why:
 - This PR is more of an excuse to trigger SonarCloud scan over and over again to test whether SonarCloud web-ui-side configuration changes have fixed the Github repository integration issue.